### PR TITLE
Split healing in smaller chuncks

### DIFF
--- a/jobs/healing/main.js
+++ b/jobs/healing/main.js
@@ -26,10 +26,7 @@ export async function executeHealingTask(){
       const task = await loadTask(syncTaskUri || healingTaskUri);
       try {
         await updateTaskStatus(task, STATUS_BUSY);
-        delta = await runHealingTask(task, syncTaskUri ? true : false);
-        if(SERVE_DELTA_FILES && healingTaskUri){
-          await publishDeltaFiles(delta);
-        }
+        await runHealingTask(task, syncTaskUri ? true : false);
         await updateTaskStatus(task, STATUS_SUCCESS);
       }
       catch(e) {


### PR DESCRIPTION
When the amount of data to heal becomes too big, the healing starts crashing with `JavaScript heap out of memory` errors. To prevent this, I tried here to split the one big healing into smaller healings, one per predicate.

This has the downside that if a healing fails in the middle, the data that has already been healed will remain healed and the generated diff files will be attached to this failed healing, even though they are consumable by the attached consumers.

I'm setting this as a draft PR for now, until I've been able to test this until a successful healing. But it takes a LOT of time :)

-----------------

Edit, some findings: I think that the calculated diff is not right, I think it contains too much data, causing the re-healing of already healed triples. I stored the diff files locally to be able to view the generated diff files. I first started a healing, stopped it after like 1h, and restarted a new one. The diff files are exactly the same even though some of the data is already healed and should not appear in the diff anymore.

```
await fs.writeFile(`/share/diffs-deletes-${(new Date()).toISOString()}.ttl`, diffs.deletes.map(t => t.nTriple).join('\n'), 'utf-8');
await fs.writeFile(`/share/diffs-inserts-${(new Date()).toISOString()}.ttl`, diffs.inserts.map(t => t.nTriple).join('\n'), 'utf-8');
```