### PR TITLE
Move additionalFilter outside of graph block

### DIFF
--- a/jobs/publishing/producer.js
+++ b/jobs/publishing/producer.js
@@ -505,9 +505,10 @@ async function isInScopeOfConfiguration(subject, config, graphFilterBuilder = ()
       ${pathToConceptSchemeString}
 
       GRAPH ?graph {
-       ?subject ?predicate ?object .
-       ${additionalFilter}
+        ?subject ?predicate ?object .
       }
+
+      ${additionalFilter}
 
       ${graphFilterBuilder()}
 


### PR DESCRIPTION
If all the data doesn't reside in the same graph, it becomes impossible to use the additional filters as expected. Moving it outside, as it's done above in the method `exportResource`, should solve the issue without side effects.