### PR TITLE
Add the option to do do diffTriplesData using files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM semtech/mu-javascript-template:1.5.0-beta.4
 LABEL maintainer="Redpencil <info@redpencil.io>"
+RUN apk add coreutils
 
 # see https://github.com/mu-semtech/mu-javascript-template for more info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM semtech/mu-javascript-template:1.5.0-beta.4
-LABEL maintainer="Redpencil <info@redpencil.io>"
-RUN apk add coreutils
+FROM openlink/virtuoso-opensource-7:7.2.6-r8-g5a27710-alpine as virtuoso
 
+FROM semtech/mu-javascript-template:1.5.0-beta.4
+
+LABEL maintainer="Redpencil <info@redpencil.io>"
+RUN apk add coreutils unixodbc
+COPY --from=virtuoso /opt/virtuoso-opensource /usr/local/virtuoso-opensource
+COPY etc/odbc.ini /etc
+COPY etc/odbcinst.ini /etc
 # see https://github.com/mu-semtech/mu-javascript-template for more info

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ The following enviroment variables can be optionally configured:
 * `PUBLICATION_MU_AUTH_ENDPOINT (default: MU_AUTH_ENDPOINT)`: Location of the mu-auth endpoint
 * `PRETTY_PRINT_DIFF_JSON (default: true)`: Whether to pretty print the diff json
 * `CONFIG_SERVICES_JSON_PATH (default: '/config/services.json')`: The services configuration path
+* `VIRTUOSO_USERNAME (default: "dba")`: The username to use when querying virtuoso using `isql`
+* `VIRTUOSO_PASSWORD (default: "dba")`: The password to use when querying virtuoso using `isql`
 
 ### API
 #### POST /delta

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The following enviroment variables can be optionally configured:
 * `CONFIG_SERVICES_JSON_PATH (default: '/config/services.json')`: The services configuration path
 * `VIRTUOSO_USERNAME (default: "dba")`: The username to use when querying virtuoso using `isql`
 * `VIRTUOSO_PASSWORD (default: "dba")`: The password to use when querying virtuoso using `isql`
+* `DELTA_CHUNK_SIZE (default: 1000000)`: The maximum size of deltas that are published
 
 ### API
 #### POST /delta

--- a/env-config.js
+++ b/env-config.js
@@ -11,6 +11,8 @@ export const PRETTY_PRINT_DIFF_JSON = process.env.PRETTY_PRINT_DIFF_JSON === 'tr
 export const CACHE_CHUNK_STATEMENT = parseInt(process.env.CACHE_CHUNK_STATEMENT || 100);
 export const CACHE_CHUNK_ARRAY = parseInt(process.env.CACHE_CHUNK_ARRAY || 10);
 export const CONFIG_SERVICES_JSON_PATH = process.env.CONFIG_SERVICES_JSON_PATH || '/config/services.json'
+export const VIRTUOSO_USERNAME = process.env.VIRTUOSO_USERNAME || "dba"
+export const VIRTUOSO_PASSWORD = process.env.VIRTUOSO_PASSWORD || "dba"
 
 export class Config {
     constructor(configData) {

--- a/env-config.js
+++ b/env-config.js
@@ -68,6 +68,8 @@ if(!process.env.HEALING_JOB_OPERATION)
   throw `Expected 'HEALING_JOB_OPERATION' should be provided.`;
 export const HEALING_JOB_OPERATION = process.env.HEALING_JOB_OPERATION;
 
+export const USE_FILE_DIFF = process.env.USE_FILE_DIFF == 'true' ? true : false ;
+
 /*
  * START EXPERIMENTAL FEATURES
  */

--- a/env-config.js
+++ b/env-config.js
@@ -13,6 +13,7 @@ export const CACHE_CHUNK_ARRAY = parseInt(process.env.CACHE_CHUNK_ARRAY || 10);
 export const CONFIG_SERVICES_JSON_PATH = process.env.CONFIG_SERVICES_JSON_PATH || '/config/services.json'
 export const VIRTUOSO_USERNAME = process.env.VIRTUOSO_USERNAME || "dba"
 export const VIRTUOSO_PASSWORD = process.env.VIRTUOSO_PASSWORD || "dba"
+export const DELTA_CHUNK_SIZE = process.env.DELTA_CHUNK_SIZE || 1000000
 
 export class Config {
     constructor(configData) {

--- a/etc/odbc.ini
+++ b/etc/odbc.ini
@@ -1,0 +1,3 @@
+[Virtuoso]
+Driver = virtuoso-odbc
+Address = virtuoso:1111

--- a/etc/odbcinst.ini
+++ b/etc/odbcinst.ini
@@ -1,0 +1,2 @@
+[virtuoso-odbc]
+Driver = /usr/local/virtuoso-opensource/lib/virtodbcu_r.so

--- a/jobs/healing/main.js
+++ b/jobs/healing/main.js
@@ -26,10 +26,7 @@ export async function executeHealingTask(){
       const task = await loadTask(syncTaskUri || healingTaskUri);
       try {
         await updateTaskStatus(task, STATUS_BUSY);
-        delta = await runHealingTask(task, syncTaskUri ? true : false);
-        if(SERVE_DELTA_FILES && healingTaskUri){
-          await publishDeltaFiles(delta);
-        }
+        delta = await runHealingTask(task, syncTaskUri ? true : false, SERVE_DELTA_FILES && healingTaskUri);
         await updateTaskStatus(task, STATUS_SUCCESS);
       }
       catch(e) {

--- a/jobs/healing/pipeline-healing.js
+++ b/jobs/healing/pipeline-healing.js
@@ -1,4 +1,8 @@
 import { querySudo as query } from '@lblod/mu-auth-sudo';
+import * as fs from 'fs';
+import * as tmp from 'tmp';
+import {execSync} from 'child_process';
+import * as Readlines from '@lazy-node/readlines';
 import { uniq } from 'lodash';
 import { sparqlEscapeString, sparqlEscapeUri, uuid } from 'mu';
 import { writeTtlFile } from '../../lib/file-helpers';

--- a/jobs/healing/pipeline-healing.js
+++ b/jobs/healing/pipeline-healing.js
@@ -86,7 +86,7 @@ export async function runHealingTask(service_config, service_export_config, task
         sourceTriples.removeCallback();
         publicationGraphTriples.removeCallback();
       } else {
-        let diffs = diffTriplesData(sourceTriples, publicationGraphTriples);
+        let diffs = diffTriplesData(service_config, sourceTriples, publicationGraphTriples);
         accumulatedDiffs.deletes = [ ...accumulatedDiffs.deletes, ...diffs.deletes ];
         accumulatedDiffs.inserts = [ ...accumulatedDiffs.inserts, ...diffs.inserts ];
       }
@@ -241,8 +241,7 @@ async function getSourceTriples(service_config, service_export_config, property,
       sourceTriples = newSourceTriples;
       scopedSourceTriplesFile.removeCallback();
     } else {
-      const diffs = diffTriplesData(scopedSourceTriples, sourceTriples);
-      console.log(`DEBUG: FILE BASED DIFF, number of inserts: ${diffs.inserts.length} | number of deletes: ${diffs.deletes.length}`)
+      const diffs = diffTriplesData(service_config, scopedSourceTriples, sourceTriples);
       sourceTriples = [ ...sourceTriples, ...diffs.inserts ];
     }
   }
@@ -437,7 +436,7 @@ function diffFiles(targetFile, sourceFile, S="50%", T="/tmp"){
 }
 
 
-function diffTriplesData(target, source) {
+function diffTriplesData(service_config, target, source) {
   //Note: this only works correctly if triples have same lexical notation.
   //So think about it, when copy pasting :-)
 
@@ -446,7 +445,7 @@ function diffTriplesData(target, source) {
     diff.deletes = source;
   } else if (source.length === 0) {
     diff.inserts = target;
-  } else if (USE_FILE_DIFF) {
+  } else if (service_config.useFileDiff) {
     console.log(`DEBUG: FILE BASED DIFF, target size is ${target.length}, source size is ${source.length}`)
     // only do the file-based diff when the dataset is large, since otherwise the overhead is too much
     let targetFile = arrayToFile(target, tmp.fileSync())

--- a/jobs/healing/pipeline-healing.js
+++ b/jobs/healing/pipeline-healing.js
@@ -237,10 +237,13 @@ async function getSourceTriples(service_config, service_export_config, property,
     console.log(`DEBUG: number of source triples: ${scopedSourceTriples.length}`)
 
     if (service_config.useFileDiff) {
+      // TODO: check if outputting all scopedSourceTriples to a file and then running `sort` and `uniq` on it is quicker
       let scopedSourceTriplesFile = arrayToFile(scopedSourceTriples, tmp.fileSync());
       const diffs = diffFiles(scopedSourceTriplesFile, sourceTriples);
       let newSourceTriples = tmp.fileSync();
-      execSync(`cat ${sourceTriples.name} ${diffs.name} | tee ${newSourceTriples.name}`, optionsNoOutput)
+      execSync(`cat ${sourceTriples.name} ${diffs.inserts.name} | tee ${newSourceTriples.name}`, optionsNoOutput)
+      diffs.inserts.removeCallback();
+      diffs.deletes.removeCallback();
       sourceTriples.removeCallback();
       sourceTriples = newSourceTriples;
       scopedSourceTriplesFile.removeCallback();

--- a/jobs/healing/pipeline-healing.js
+++ b/jobs/healing/pipeline-healing.js
@@ -267,8 +267,8 @@ function diffFiles(targetFile, sourceFile, S="50%", T="/tmp"){
   let output1 = tmp.fileSync();
   let output2 = tmp.fileSync();
 
-  execSync(`comm -23 ${sorted1.name} ${sorted2.name} | tee ${output1.name}`)
-  execSync(`comm -13 ${sorted1.name} ${sorted2.name} | tee ${output2.name}`)
+  execSync(`comm -23 ${sorted1.name} ${sorted2.name} | tee ${output1.name}`, optionsNoOutput)
+  execSync(`comm -13 ${sorted1.name} ${sorted2.name} | tee ${output2.name}`, optionsNoOutput)
 
   let inserts = lines(output1.name)
   let deletes = lines(output2.name)
@@ -295,6 +295,7 @@ function diffTriplesData(target, source) {
   } else if (source.length === 0) {
     diff.inserts = target;
   } else if (USE_FILE_DIFF) {
+    console.log(`DOING FILE BASED DIFF, target size is ${target.length}, source size is ${source.length}`)
     // only do the file-based diff when the dataset is large, since otherwise the overhead is too much
     let targetFile = arrayToFile(target, tmp.fileSync())
     let sourceFile = arrayToFile(source, tmp.fileSync())

--- a/jobs/healing/pipeline-healing.js
+++ b/jobs/healing/pipeline-healing.js
@@ -9,6 +9,7 @@ import { writeTtlFile } from '../../lib/file-helpers';
 import { appendTaskResultFile } from '../../lib/task';
 import {batchedUpdate, serializeTriple, sparqlEscapePredicate} from '../../lib/utils';
 import {
+  DELTA_CHUNK_SIZE,
   MU_AUTH_ENDPOINT,
   PUBLICATION_MU_AUTH_ENDPOINT,
   PUBLICATION_VIRTUOSO_ENDPOINT,
@@ -107,7 +108,7 @@ export async function runHealingTask(service_config, service_export_config, task
       publicationEndpoint = PUBLICATION_VIRTUOSO_ENDPOINT;
     }
 
-    let fileDiffMaxArraySize = 1000000;
+    let fileDiffMaxArraySize = DELTA_CHUNK_SIZE;
     if (service_config.useFileDiff) {
       let deletes = [];
       console.log("DEBUG: getting data from deletes file")

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.15.2",
   "description": "Microservice to maintain the publication graph during delta production process",
   "dependencies": {
+    "@lazy-node/readlines": "^3.0.2",
     "@lblod/mu-auth-sudo": "https://github.com/lblod/mu-auth-sudo.git#b2d957bc83882db60efa131621840c0d8e92b242",
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.11",
-    "@lazy-node/readlines": "^3.0.2"
+    "tmp": "^0.2.1"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@lblod/mu-auth-sudo": "https://github.com/lblod/mu-auth-sudo.git#b2d957bc83882db60efa131621840c0d8e92b242",
     "fs-extra": "^8.0.1",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.11",
+    "@lazy-node/readlines": "^3.0.2"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This option is configurable with the USE_FILE_DIFF environment variable.
On big datasets this means javascript doesn't have to hold everything in memory and can let `sort` and `comm` do the heavy lifting