### PR TITLE
Fix: wrong arguments to Array.map()

### DIFF
--- a/jobs/publishing/main.js
+++ b/jobs/publishing/main.js
@@ -26,7 +26,7 @@ export async function updatePublicationGraph(service_config, service_export_conf
           .value();
 
     if(deletes.length){
-      await batchedUpdate(service_config, deletes.map(service_config, t => serializeTriple(t)),
+      await batchedUpdate(service_config, deletes.map(t => serializeTriple(t)),
                           service_config.publicationGraph,
                           'DELETE',
                           service_config.updatePublicationGraphSleep,


### PR DESCRIPTION
This is clearly YET ANOTHER silly mistake in a critical piece of software. THIS WAS CLEARLY NOT TESTED WHEN RELEASED.

I'm sorry about the strong language, but this is the third silly mistake I had to fix and it is costing me valuable time.