### PR TITLE
feature: single delta location

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ The json file represents a dictionary of service configurations with the key bei
 ```json
     "besluiten": {
         "deltaInterval": 10000,
-        "deltaPath": "/besluiten/delta",
         "errorCreatorUri": "http://lblod.data.gift/services/delta-producer-publication-graph-maintainer-besluiten",
         "errorGraph": "http://mu.semte.ch/graphs/harvesting",
         "exportConfigPath": "/config/besluiten/export.json",
@@ -245,7 +244,7 @@ The following enviroment variables can be optionally configured:
 * `CONFIG_SERVICES_JSON_PATH (default: '/config/services.json')`: The services configuration path
 * `MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE (defaut: 100)`: A delta is an object containing `inserts` and `deletes` properties. This variables specs the max. number of elements in these properties. This is mainly to tweak the size of the published delta files; where in some cases we need to tweak this number to reduce load on the consumers.
 * `MAX_DELTAS_PER_FILE: (default 10)`: Related to `MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE`, a delta-file bundles an array of delta-objects, here you configure the number of these delta-object per delta file. Again something to tweak only if you need to take care of the (potential) load on consumers.
-
+* `DELTA_PATH`: The path where the delta messages get delivered
 
 ### API
 #### POST /delta

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ import { updateSudo } from '@lblod/mu-auth-sudo';
 import bodyParser from 'body-parser';
 import { app, errorHandler, sparqlEscapeUri, uuid } from 'mu';
 import {
-  Config, CONFIG_SERVICES_JSON_PATH, LOG_INCOMING_DELTA
+  Config, CONFIG_SERVICES_JSON_PATH, DELTA_PATH, LOG_INCOMING_DELTA
 } from './env-config';
 import { getDeltaFiles, publishDeltaFiles } from './files-publisher/main';
 import { executeHealingTask } from './jobs/healing/main';
@@ -19,30 +19,91 @@ app.use( bodyParser.json({
 let services = require(CONFIG_SERVICES_JSON_PATH);
 
 console.log("Services config is: ", services);
-for (const name in services){
-  let service = services[name];
-  const service_config = new Config(service);
-  const service_export_config = loadConfiguration(service_config.exportConfigPath);
+let configPerService = {}
+let producerQueues = {}
 
-  const producerQueue = new ProcessingQueue(service_config);
+// mapping from type to the name of each service that is interested in it, an empty array indicates that the type can be ignored
+let interestedTypes = {}
+for (const name in services) {
+  let service = services[name]
+  const serviceConfig = new Config(service);
+  const serviceExportConfig = loadConfiguration(serviceConfig.exportConfigPath);
+  const types = require(serviceConfig.exportConfigPath).export.map(config=>config.type);
+  for (const type of types){
+    interestedTypes[type] = [...(interestedTypes[type] || []), name];
+  }
+  configPerService[name] = {
+    serviceConfig: serviceConfig,
+    serviceExportConfig: serviceExportConfig,
+    interestedTypes: interestedTypes
+  }
+  producerQueues[name] = new ProcessingQueue(serviceConfig);
+}
 
-  app.post(service_config.deltaPath, async function (req, res) {
+let subjectTypeCache = new NodeCache( { stdTTL: 300 } );
+// The types of a delta consists of two parts
+// - the types contained in the delta payload
+// - the types contained in the database about the delta subjects
+async function getTypesFromDelta(delta) {
+  let indelta = new Set([
+    ...delta.flatMap(d => d.inserts).filter(i => i.predicate.value === "http://www.w3.org/1999/02/22-rdf-syntax-ns#type").map(i => i.object.value),
+    ...delta.flatMap(d => d.deletes).filter(i => i.predicate.value === "http://www.w3.org/1999/02/22-rdf-syntax-ns#type").map(i => i.object.value)
+  ]);
+  let subjects = new Set([
+    ...delta.flatMap(d => d.inserts).map(i => i.subject.value),
+    ...delta.flatMap(d => d.deletes).map(i => i.subject.value)
+  ]);
+  let inDb = new Set();
+  for (const subject of subjects) {
+    let types = subjectTypeCache.get(subject)
+    console.log(`Cached types for ${subject} are ${JSON.stringify(types)}`)
+    if (types === undefined) {
+      const result = await query(`
+      SELECT ?type WHERE {
+        ${sparqlEscapeUri(subject)} a ?type.
+      }`);
+      types = result.results.bindings.map(t => t.type.value);
+      subjectTypeCache.set(subject, types)
+    }
+    types.forEach(t=>inDb.add(t))
+  }
+  return [...new Set([...indelta, ...inDb])];
+}
+
+app.post(DELTA_PATH, async function (req, res) {
+  const body = req.body;
+  // Get the types from the delta message
+  const typesFromDelta = await getTypesFromDelta(body);
+  if (LOG_INCOMING_DELTA) {
+    console.log(`Receiving delta ${JSON.stringify(body)}`);
+    console.log(`Delta has types ${JSON.stringify(typesFromDelta)}`);
+  }
+  // Ignore errors in delta's
+  let typesToIgnore = ["http://open-services.net/ns/core#Error", "http://redpencil.data.gift/vocabularies/deltas/Error"];
+  if (typesFromDelta.every(v => typesToIgnore.includes(v))) {
+    res.status(202).send();
+    return;
+  }
+  // only send the delta to relevant services
+  let serviceKeys = typesFromDelta.flatMap(type => (interestedTypes[type]) || []);
+  // but if the types match no services, default to sending it to all services
+  if (serviceKeys.length === 0) serviceKeys = Object.keys(services);
+  for (const name in services) {
+    const serviceConfig = configPerService[name].serviceConfig;
+    const serviceExportConfig = configPerService[name].serviceExportConfig;
+    const producerQueue = producerQueues[name];
     try {
-      const body = req.body;
-
-      if (LOG_INCOMING_DELTA)
-        console.log(`Receiving delta ${JSON.stringify(body)}`);
-
-      if (await doesDeltaContainNewTaskToProcess(service_config, body)) {
+      // only check if a delta contains a new task if one of the types is task
+      if (typesFromDelta.includes("http://redpencil.data.gift/vocabularies/tasks/Task") && await doesDeltaContainNewTaskToProcess(serviceConfig, body)) {
         //From here on, the database is source of truth and the incoming delta was just a signal to start
         console.log(`Healing process (or initialSync) will start.`);
         console.log(`There were still ${producerQueue.queue.length} jobs in the queue`);
         console.log(`And the queue executing state is on ${producerQueue.executing}.`);
         producerQueue.queue = []; //Flush all remaining jobs, we don't want moving parts cf. next comment
         producerQueue.addJob(async () => {
-          return await executeHealingTask(service_config, service_export_config);
+          return await executeHealingTask(serviceConfig, serviceExportConfig);
         });
-      } else if (await isBlockingJobActive(service_config)) {
+      } else if (await isBlockingJobActive(serviceConfig)) {
         // During the healing (and probably initial sync too) we want as few as much moving parts,
         // If a delta comes in while the healing process is busy, this might yield inconsistent/difficult to troubleshoot results.
         // Suppose:
@@ -67,7 +128,7 @@ for (const name in services){
         //    by the delta-file service itself
         //  - Some kind of multi lock system, where all the services involved should tell they are ready to be healed.
         console.info('Blocking jobs are active, skipping incoming deltas');
-      } else if (service_config.waitForInitialSync && !await hasInitialSyncRun(service_config)) {
+      } else if (serviceConfig.waitForInitialSync && !await hasInitialSyncRun(serviceConfig)) {
         // To produce and publish consistent deltas an initial sync needs to have run.
         // The initial sync job produces a dump file which provides a cartesian starting point for the delta diff files to make sense on.
         // It doesn't produce delta diff files, because performance.
@@ -78,32 +139,38 @@ for (const name in services){
       } else {
         //normal operation mode: maintaining the publication graph
         //Put in a queue, because we want to make sure to have them ordered.
-        producerQueue.addJob(async () => await runPublicationFlow(service_config, service_export_config, body));
+        //but only send the delta messages to the parts that are interested in it to avoid flooding the other services
+        if (serviceKeys.includes(name)) {
+          producerQueue.addJob(async () => await runPublicationFlow(serviceConfig, serviceExportConfig, body));
+        }
       }
       res.status(202).send();
     } catch (error) {
       console.error(error);
-      await storeError(service_config, error);
+      await storeError(serviceConfig, error);
       res.status(500).send();
     }
-  });
+  }
+});
 
-  async function runPublicationFlow(service_config, service_export_config, deltas) {
+  async function runPublicationFlow(serviceConfig, serviceExportConfig, deltas) {
     try {
-      const insertedDeltaData = await updatePublicationGraph(service_config, service_export_config, deltas);
-      if (service_config.serveDeltaFiles) {
-        await publishDeltaFiles(service_config, insertedDeltaData);
+      const insertedDeltaData = await updatePublicationGraph(serviceConfig, serviceExportConfig, deltas);
+      if (serviceConfig.serveDeltaFiles) {
+        await publishDeltaFiles(serviceConfig, insertedDeltaData);
       }
     } catch (error) {
       console.error(error);
-      await storeError(service_config, error);
+      await storeError(serviceConfig, error);
     }
   }
 
-  if (service_config.serveDeltaFiles) {
+for (const name in services) {
+  const serviceConfig = configPerService[name].serviceConfig;
+  if (serviceConfig.serveDeltaFiles) {
 //This endpoint only makes sense if serveDeltaFiles is set to true;
-    app.get(service_config.filesPath, async function (req, res) {
-      const files = await getDeltaFiles(service_config, req.query.since);
+    app.get(serviceConfig.filesPath, async function (req, res) {
+      const files = await getDeltaFiles(serviceConfig, req.query.since);
       res.json({data: files});
     });
   }
@@ -111,11 +178,11 @@ for (const name in services){
 // This is useful if the data in the files is confidential
 // Note that you will need to configure mu-auth so it can make sense out of it
 // TODO: probably this functionality will move somewhere else
-  app.post(service_config.loginPath, async function (req, res) {
+  app.post(serviceConfig.loginPath, async function (req, res) {
     try {
 
       // 0. To avoid false sense of security, login only makes sense if accepted key is configured
-      if (!service_config.key) {
+      if (!serviceConfig.key) {
         throw "No key configured in service.";
       }
 
@@ -123,7 +190,7 @@ for (const name in services){
       const sessionUri = req.get('mu-session-id');
 
       // 2. validate credentials
-      if (req.get("key") !== service_config.key) {
+      if (req.get("key") !== serviceConfig.key) {
         throw "Key does not match";
       }
 
@@ -131,8 +198,8 @@ for (const name in services){
       updateSudo(`
       PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
       INSERT DATA {
-        GRAPH ${sparqlEscapeUri(service_config.account_graph)} {
-          ${sparqlEscapeUri(sessionUri)} muAccount:account ${sparqlEscapeUri(service_config.account)}.
+        GRAPH ${sparqlEscapeUri(serviceConfig.account_graph)} {
+          ${sparqlEscapeUri(sessionUri)} muAccount:account ${sparqlEscapeUri(serviceConfig.account)}.
         }
       }`);
 

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 import { updateSudo } from '@lblod/mu-auth-sudo';
 import bodyParser from 'body-parser';
 import { app, errorHandler, sparqlEscapeUri, uuid } from 'mu';
+import { querySudo as query } from '@lblod/mu-auth-sudo';
 import {
   Config, CONFIG_SERVICES_JSON_PATH, DELTA_PATH, LOG_INCOMING_DELTA
 } from './env-config';
@@ -10,6 +11,7 @@ import { updatePublicationGraph } from './jobs/publishing/main';
 import { doesDeltaContainNewTaskToProcess, hasInitialSyncRun, isBlockingJobActive } from './jobs/utils';
 import { ProcessingQueue } from './lib/processing-queue';
 import {loadConfiguration, storeError} from './lib/utils';
+import NodeCache from 'node-cache';
 
 app.use( bodyParser.json({
   type: function(req) { return /^application\/json/.test( req.get('content-type') ); },

--- a/env-config.js
+++ b/env-config.js
@@ -11,7 +11,10 @@ export const PRETTY_PRINT_DIFF_JSON = process.env.PRETTY_PRINT_DIFF_JSON === 'tr
 export const MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE = parseInt(process.env.MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE || 100);
 export const MAX_DELTAS_PER_FILE = parseInt(process.env.MAX_DELTAS_PER_FILE || 10);
 export const CONFIG_SERVICES_JSON_PATH = process.env.CONFIG_SERVICES_JSON_PATH || '/config/services.json';
-
+export const DELTA_PATH = process.env.DELTA_PATH
+if (DELTA_PATH === undefined) {
+  throw `Expected 'DELTA_PATH' environment variable should be provided.`;
+}
 export class Config {
   constructor(configData) {
     this.exportConfigPath = configData.exportConfigPath;
@@ -105,9 +108,6 @@ export class Config {
     /*
      * PATHS
      */
-    if (!configData.deltaPath)
-        throw `Expected 'deltaPath' should be provided.`;
-    this.deltaPath = configData.deltaPath;
     if (!configData.filesPath)
         throw `Expected 'filesPath' should be provided.`;
     this.filesPath = configData.filesPath;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@lblod/mu-auth-sudo": "0.6.1",
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.11",
+    "node-cache": "^5.1.2",
     "tmp": "^0.2.1"
   },
   "scripts": {


### PR DESCRIPTION
replaces #17 

I (@cecemel ) am writing on behalf of JB-Baert, as he no longer works with us, which is unfortunate. 
This is an attempt to optimize the producer side. 
Previously, for every incoming delta, all delta-streams would fire requests to the database and determine if the delta is relevant for them based on the information. 
So, essentially, if you have `subsidies` and, for example, `persons-sensitive`, two identical calls would be made to the database. 
During periods of high load, this could become problematic.

Now that we have consolidated all streams and it is managed by one instance, we can make a single call to the database to determine which delta-stream should be activated, by pre-filtering the information. 

The general strategy would be:
 - check the `type` of the ?s of the delta (note: if delete; you will need to figure out this info from the delta; else you can use the db)
 - if you have the type; check the config files and see if there is any configuration for this specific type.
   -  dispatch to the correct stream.
- if no matching type is found; you dispatch to all streams as fallback.
-

This PR probably needs further refinement.
