### PR TITLE
Feature/construct queries on file attempt 2

### DIFF
--- a/jobs/healing/utils.js
+++ b/jobs/healing/utils.js
@@ -37,7 +37,7 @@ export async function createResultsContainer(serviceConfig, task, nTriples, subj
   await appendTaskResultFile(task, fileContainer, turtleFile);
 }
 
-export function generateGetPublicationTriplesQuery(config, property, publicationGraph, asConstructQuery = false) {
+export function generateGetPublicationTriplesQuery({ config, property, publicationGraph, asConstructQuery = false }) {
 
   const resultsExpression = asConstructQuery ?
         `CONSTRUCT { ?subject ?predicate ?object }` :
@@ -66,7 +66,7 @@ export async function getScopedPublicationTriples(serviceConfig, config, propert
   console.log(`Publication triples using file? ${serviceConfig.useFileDiff}`);
   const endpoint = serviceConfig.useVirtuosoForExpensiveSelects ? PUBLICATION_VIRTUOSO_ENDPOINT : PUBLICATION_MU_AUTH_ENDPOINT;
 
-  const selectFromPublicationGraph = generateGetPublicationTriplesQuery(config, property, publicationGraph);
+  const selectFromPublicationGraph = generateGetPublicationTriplesQuery({ config, property, publicationGraph });
 
   console.log(`Hitting database ${endpoint} with expensive query`);
   const result = await batchedQuery(selectFromPublicationGraph,
@@ -77,7 +77,13 @@ export async function getScopedPublicationTriples(serviceConfig, config, propert
   return reformatQueryResult(result, property);
 }
 
-export function generateGetSourceTriplesQuery(config, property, publicationGraph, conceptSchemeUri, asConstructQuery = false) {
+export function generateGetSourceTriplesQuery({
+  config,
+  property,
+  publicationGraph,
+  conceptSchemeUri,
+  asConstructQuery = false
+}) {
   const { additionalFilter,
           pathToConceptScheme,
           graphsFilter,
@@ -161,7 +167,7 @@ export async function getScopedSourceTriples(serviceConfig, config, property, pu
   const endpoint = serviceConfig.useVirtuosoForExpensiveSelects ? VIRTUOSO_ENDPOINT : MU_AUTH_ENDPOINT;
   console.log(`Hitting database ${endpoint} with expensive queries`);
 
-  const selectFromDatabase = generateGetSourceTriplesQuery(config, property, publicationGraph, conceptSchemeUri);
+  const selectFromDatabase = generateGetSourceTriplesQuery({config, property, publicationGraph, conceptSchemeUri});
 
   const result = await batchedQuery(selectFromDatabase,
                                     healingOptionsForProperty.queryChunkSize,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,13 +26,14 @@ export function serializeTriplePart(triplePart){
   }
   else if (triplePart.type === 'literal' || triplePart.type === 'typed-literal') {
     if(triplePart.datatype) {
-        return `${sparqlEscapeString(triplePart.value)}^^${sparqlEscapeUri(triplePart.datatype)}`;
+        // Cast to string, because subtle serialization issues from virtuoso: json -> SELECT vs CONSTRUCT returns different ints formats
+        return `${sparqlEscapeString(String(triplePart.value))}^^${sparqlEscapeUri(triplePart.datatype)}`;
     }
     else if(triplePart.lang) {
-      return `${sparqlEscapeString(triplePart.value)}@${triplePart.lang}`;
+      return `${sparqlEscapeString(String(triplePart.value))}@${triplePart.lang}`;
     }
     else {
-      return sparqlEscapeString(triplePart.value);
+      return sparqlEscapeString(String(triplePart.value));
     }
   }
   else {


### PR DESCRIPTION
This is an attempt at dealing with inconsistent response from virtuoso and very large datasets.
SELECT queries silently return too few triples. An approach would be to paginate the select results (and by doing so, as a subquery, like explained here: https://vos.openlinksw.com/owiki/wiki/VOS/VirtTipsAndTricksHowToHandleBandwidthLimitExceed)
However; sorting is extremely slow. The only workable solution was to work with CONSTRUCT queries.
This PR deals only for on disk diffing. 