### PR TITLE
Fix loading config file and its defaults

### DIFF
--- a/env-config.js
+++ b/env-config.js
@@ -1,5 +1,5 @@
-export const LOG_INCOMING_DELTA = process.env.LOG_INCOMING_DELTA || false;
-export const LOG_DELTA_REWRITE = process.env.LOG_DELTA_REWRITE || false;
+export const LOG_INCOMING_DELTA = process.env.LOG_INCOMING_DELTA === 'true';
+export const LOG_DELTA_REWRITE = process.env.LOG_DELTA_REWRITE === 'true';
 export const VIRTUOSO_ENDPOINT = process.VIRTUOSO_ENDPOINT || 'http://virtuoso:8890/sparql';
 export const MU_AUTH_ENDPOINT = process.MU_AUTH_ENDPOINT || 'http://database:8890/sparql';
 
@@ -8,8 +8,8 @@ export const PUBLICATION_VIRTUOSO_ENDPOINT = process.env.PUBLICATION_VIRTUOSO_EN
 export const PUBLICATION_MU_AUTH_ENDPOINT = process.env.PUBLICATION_MU_AUTH_ENDPOINT || MU_AUTH_ENDPOINT;
 //FILES PUBLISHER
 export const PRETTY_PRINT_DIFF_JSON = process.env.PRETTY_PRINT_DIFF_JSON === 'true';
-export const MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE = parseInt(process.env.MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE || 100);
-export const MAX_DELTAS_PER_FILE = parseInt(process.env.MAX_DELTAS_PER_FILE || 10);
+export const MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE = parseInt(process.env.MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE) || 100;
+export const MAX_DELTAS_PER_FILE = parseInt(process.env.MAX_DELTAS_PER_FILE) || 10;
 export const CONFIG_SERVICES_JSON_PATH = process.env.CONFIG_SERVICES_JSON_PATH || '/config/services.json';
 
 export class Config {
@@ -52,12 +52,12 @@ export class Config {
     this.insertionContainer = 'http://redpencil.data.gift/id/concept/HealingProcess/InsertionContainer';
 
     this.reportingFilesGraph = configData.reportingFilesGraph;
-    this.queuePollInterval = configData.queuePollInterval || 60000;
+    this.queuePollInterval = parseInt(configData.queuePollInterval) || 60000;
 
-    this.healingMaxTriplesInMemory = parseInt(configData.healingMaxTriplesInMemory || 100000);
-    this.healingInitialBatchSizeInsert = parseInt(configData.healingInitialBatchSizeInsert || 1000);
-    this.updatePublicationGraphSleep = parseInt(configData.updatePublicationGraphSleep || 1000);
-    this.skipMuAuthDeltaFolding = configData.skipMuAuthDeltaFolding || false;
+    this.healingMaxTriplesInMemory = parseInt(configData.healingMaxTriplesInMemory) || 100000;
+    this.healingInitialBatchSizeInsert = parseInt(configData.healingInitialBatchSizeInsert) || 1000;
+    this.updatePublicationGraphSleep = parseInt(configData.updatePublicationGraphSleep) || 1000;
+    this.skipMuAuthDeltaFolding = configData.skipMuAuthDeltaFolding === 'true' || configData.skipMuAuthDeltaFolding === true;
 
     this.muCallScopeIdPublicationGraphMaintenance = configData.muCallScopeIdPublicationGraphMaintenance
         || 'http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance';
@@ -66,7 +66,7 @@ export class Config {
         || 'http://redpencil.data.gift/id/concept/muScope/deltas/initialSync';
 
     //mainly for debugging purposes
-    this.waitForInitialSync = configData.waitForInitialSync || true;
+    this.waitForInitialSync = !(configData.waitForInitialSync === 'false' || configData.waitForInitialSync === false);
 
     if (!configData.publicationGraph)
         throw `Expected 'publicationGraph' should be provided.`;
@@ -84,19 +84,19 @@ export class Config {
      * START EXPERIMENTAL FEATURES
      */
     //SKIP MU_AUTH
-    this.useVirtuosoForExpensiveSelects = configData.useVirtuosoForExpensiveSelects || false;
-    this.skipMuAuthInitialSync = configData.skipMuAuthInitialSync || false;
-    this.skipMuAuthHealing = configData.skipMuAuthHealing || false;
+    this.useVirtuosoForExpensiveSelects = configData.useVirtuosoForExpensiveSelects === 'true' || configData.useVirtuosoForExpensiveSelects === true;
+    this.skipMuAuthInitialSync = configData.skipMuAuthInitialSync === 'true' || configData.skipMuAuthInitialSync === true;
+    this.skipMuAuthHealing = configData.skipMuAuthHealing === 'true' || configData.skipMuAuthHealing === true;
 
     //FILES PUBLISHER
-    this.serveDeltaFiles = configData.serveDeltaFiles || false;
-    this.logOutgoingDelta = configData.logOutgoingDelta || false;
-    this.deltaInterval = configData.deltaInterval || 1000;
+    this.serveDeltaFiles = configData.serveDeltaFiles === 'true'|| configData.serveDeltaFiles === true;
+    this.logOutgoingDelta = configData.logOutgoingDelta === 'true' || configData.logOutgoingDelta === true;
+    this.deltaInterval = parseInt(configData.deltaInterval) || 1000;
     this.errorGraph = configData.errorGraph || 'http://mu.semte.ch/graphs/system/errors';
     this.relativeFilePath = configData.relativeFilePath || 'deltas';
     this.filesGraph = configData.filesGraph || 'http://mu.semte.ch/graphs/public';
 
-    this.useFileDiff = configData.useFileDiff || false;
+    this.useFileDiff = configData.useFileDiff === 'true' || configData.useFileDiff === true;
 
     /*
      * END EXPERIMENTAL FEATURES


### PR DESCRIPTION
Before this PR, there where statements like the following:

```javascript
this.value = config.value || true;
```

But `this.value` would always be true, even if `config.value` was false. This PR aims to fix these issues. In some cases, the boolean logic is swapped around because `false` is the default instead of `true`. Integer parsing is also done differently now: `parseInt(value) || 10` instead of `parseInt(value || 10)` (for cases where `value` is something like true etc.).