### PR TITLE
Add support for config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,131 @@ export default [
   // Other delta listeners
 ]
 ```
-### configuration file
+### Configuration File
+
+#### config.json
+
+The service's configuration file has the following format:
+```json
+{
+  "NAME-OF-STREAM-1": {
+    "key-A": "value-A",
+    "key-B": "value-B",
+    "key-C": "value-C"
+  },
+  "NAME-OF-STREAM-2": {
+    "key-X": "value-X",
+    "key-Y": "value-Y",
+    "key-Z": "value-Z"
+  }
+}
+```
+
+Check [the example](#Example) section below for an example config snippet with configured parameters.
+
+#### config.override.json
+
+This config file is optional and allows to override specific configuration keys for local development purposes or server deploys. The override behavior is "total" and only one level deep (i.e., values are completely overriden at their root-level without any exception:
+```python
+final["delta-stream"]["key"] = override["delta-stream"]["key"] if override["delta-stream"]["key"] exists else original["delta-stream"]["key"])
+```
+
+There are three situations to consider:
+
+##### Regular Config + No Override
+
+Original config:
+```
+{
+  "submissions": {
+    "key": "B"
+  },
+  "worship-submissions": {
+    "useFileDiff": true,
+  }
+}
+```
+with no overrides => **Final config = Original config**.
+
+##### Regular Config + Override
+
+Original config:
+```
+{
+  "submissions": {
+    "key": "B",
+    "useFileDiff": true,
+    "queuePollInterval": 3000
+  },
+  "worship-submissions": {
+    "useFileDiff": true,
+    "queuePollInterval": 3000
+  }
+}
+```
+with the following override config:
+```
+{
+  "submissions": {
+    "key": "NEW_B",
+    "queuePollInterval": 5000
+  },
+  "worship-submissions": {
+    "useFileDiff": false,
+  }
+}
+```
+leads to the following **final config**:
+```
+{
+  "submissions": {
+    "key": "NEW_B",
+    "useFileDiff": true,
+    "queuePollInterval": 5000
+  },
+  "worship-submissions": {
+    "useFileDiff": false,
+    "queuePollInterval": 3000
+  }
+}
+```
+
+##### Regular Config + Nested Override
+
+Original config is:
+```
+{
+  "submissions": {
+    "key": "B"
+  },
+  "worship-submissions": {
+    "useFileDiff": false,
+    "useVirtuosoForExpensiveSelects": [false, false]
+  }
+}
+```
+with the following override:
+```
+{
+  "worship-submissions": {
+    "useVirtuosoForExpensiveSelects": [true, true]
+  }
+}
+```
+will become:
+```
+{
+  "submissions": {
+    "key": "B"
+  },
+  "worship-submissions": {
+    "useFileDiff": false,
+    "useVirtuosoForExpensiveSelects": [true, true]
+  }
+}
+```
+
+The user will also receive a **warning** that their original value is being completely replaced by a new object.
 
 ## simple mode
 For example:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There are three situations to consider:
 ##### Regular Config + No Override
 
 Original config:
-```
+```json
 {
   "submissions": {
     "key": "B"
@@ -92,7 +92,7 @@ with no overrides => **Final config = Original config**.
 ##### Regular Config + Override
 
 Original config:
-```
+```json
 {
   "submissions": {
     "key": "B",
@@ -106,7 +106,7 @@ Original config:
 }
 ```
 with the following override config:
-```
+```json
 {
   "submissions": {
     "key": "NEW_B",
@@ -118,7 +118,7 @@ with the following override config:
 }
 ```
 leads to the following **final config**:
-```
+```json
 {
   "submissions": {
     "key": "NEW_B",
@@ -135,7 +135,7 @@ leads to the following **final config**:
 ##### Regular Config + Nested Override
 
 Original config is:
-```
+```json
 {
   "submissions": {
     "key": "B"
@@ -147,7 +147,7 @@ Original config is:
 }
 ```
 with the following override:
-```
+```json
 {
   "worship-submissions": {
     "useVirtuosoForExpensiveSelects": [true, true]
@@ -155,7 +155,7 @@ with the following override:
 }
 ```
 will become:
-```
+```json
 {
   "submissions": {
     "key": "B"
@@ -172,7 +172,7 @@ The user will also receive a **warning** that their original value is being comp
 ## simple mode
 For example:
 
-```
+```json
 {
   "export": [
     {

--- a/README.md
+++ b/README.md
@@ -289,7 +289,10 @@ A resource may have multiple types and therefore map to multiple export configur
 
 #### Deltastream configuration
 The deltastream configuration allows for multiple deltastreams in one instance, it is specified by `CONFIG_SERVICES_JSON_PATH`.
+
 The json file represents a dictionary of service configurations with the key being the name of the service and the value the configuration.
+
+In order to add configuration overrides, use `CONFIG_SERVICES_OVERRIDE_JSON_PATH` to specify the file path for your configuration override file.
 
 ##### Properties
 

--- a/app.js
+++ b/app.js
@@ -28,12 +28,10 @@ if (fs.existsSync(CONFIG_SERVICES_OVERRIDE_JSON_PATH)) {
 for (const name in services){
   let service = services[name];
   let service_override = services_override[name] || {};
-  const service_config = new Config(service, service_override);
+  const service_config = new Config(name, service, service_override);
   const service_export_config = loadConfiguration(service_config.exportConfigPath);
 
   const producerQueue = new ProcessingQueue(service_config);
-
-  console.log(name, "config is:", service_config);
 
   app.post(service_config.deltaPath, async function (req, res) {
     try {

--- a/app.js
+++ b/app.js
@@ -11,17 +11,23 @@ import { doesDeltaContainNewTaskToProcess, hasInitialSyncRun, isBlockingJobActiv
 import { ProcessingQueue } from './lib/processing-queue';
 import {loadConfiguration, storeError} from './lib/utils';
 
+import fs from 'fs';
+
 app.use( bodyParser.json({
   type: function(req) { return /^application\/json/.test( req.get('content-type') ); },
   limit: '500mb'
 }));
 
 let services = require(CONFIG_SERVICES_JSON_PATH);
-let services_override = require(CONFIG_SERVICES_OVERRIDE_JSON_PATH);
+
+let services_override = {};
+if (fs.existsSync(CONFIG_SERVICES_OVERRIDE_JSON_PATH)) {
+  services_override = require(CONFIG_SERVICES_OVERRIDE_JSON_PATH);
+}
 
 for (const name in services){
   let service = services[name];
-  let service_override = services_override[name];
+  let service_override = services_override[name] || {};
   const service_config = new Config(service, service_override);
   const service_export_config = loadConfiguration(service_config.exportConfigPath);
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ import { updateSudo } from '@lblod/mu-auth-sudo';
 import bodyParser from 'body-parser';
 import { app, errorHandler, sparqlEscapeUri, uuid } from 'mu';
 import {
-  Config, CONFIG_SERVICES_JSON_PATH, LOG_INCOMING_DELTA
+  Config, CONFIG_SERVICES_JSON_PATH, CONFIG_SERVICES_OVERRIDE_JSON_PATH, LOG_INCOMING_DELTA
 } from './env-config';
 import { getDeltaFiles, publishDeltaFiles } from './files-publisher/main';
 import { executeHealingTask } from './jobs/healing/main';
@@ -17,14 +17,17 @@ app.use( bodyParser.json({
 }));
 
 let services = require(CONFIG_SERVICES_JSON_PATH);
+let services_override = require(CONFIG_SERVICES_OVERRIDE_JSON_PATH);
 
-console.log("Services config is: ", services);
 for (const name in services){
   let service = services[name];
-  const service_config = new Config(service);
+  let service_override = services_override[name];
+  const service_config = new Config(service, service_override);
   const service_export_config = loadConfiguration(service_config.exportConfigPath);
 
   const producerQueue = new ProcessingQueue(service_config);
+
+  console.log(name, "config is:", service_config);
 
   app.post(service_config.deltaPath, async function (req, res) {
     try {

--- a/env-config.js
+++ b/env-config.js
@@ -14,7 +14,8 @@ export const CONFIG_SERVICES_JSON_PATH = process.env.CONFIG_SERVICES_JSON_PATH |
 export const CONFIG_SERVICES_OVERRIDE_JSON_PATH = process.env.CONFIG_SERVICES_OVERRIDE_JSON_PATH || '/config/services.override.json';
 
 export class Config {
-  constructor(configData, configOverrideData) {
+  constructor(name, configData, configOverrideData) {
+    this.name = name;
     this.exportConfigPath = configData.exportConfigPath;
     this.publisherUri = configData.publisherUri;
     //TODO: why here?
@@ -122,7 +123,20 @@ export class Config {
 
     // Apply configuration overrides, if any exist
     for (let key in configOverrideData) {
+      if(typeof(configOverrideData[key]) == "object") {
+        console.log(`WARNING: The "${key}" key has an object as a value, which will completely overwrite the original one.`)
+        console.log(`WARNING:
+        {
+          "${key}": ${this[key]}
+        }
+        will become
+        {
+          "${key}": ${JSON.stringify(configOverrideData[key])}
+        }`)
+      }
       this[key] = configOverrideData[key];
     }
+
+    console.log(name, "config is:", this);
   }
 }

--- a/env-config.js
+++ b/env-config.js
@@ -121,10 +121,8 @@ export class Config {
     this.account_graph = configData.account_graph || 'http://mu.semte.ch/graphs/diff-producer/login';
 
     // Apply configuration overrides, if any exist
-    if (configOverrideData != undefined) {
-      for (let key in configOverrideData) {
-        this[key] = configOverrideData[key];
-      }
+    for (let key in configOverrideData) {
+      this[key] = configOverrideData[key];
     }
   }
 }

--- a/env-config.js
+++ b/env-config.js
@@ -11,9 +11,10 @@ export const PRETTY_PRINT_DIFF_JSON = process.env.PRETTY_PRINT_DIFF_JSON === 'tr
 export const MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE = parseInt(process.env.MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE) || 100;
 export const MAX_DELTAS_PER_FILE = parseInt(process.env.MAX_DELTAS_PER_FILE) || 10;
 export const CONFIG_SERVICES_JSON_PATH = process.env.CONFIG_SERVICES_JSON_PATH || '/config/services.json';
+export const CONFIG_SERVICES_OVERRIDE_JSON_PATH = process.env.CONFIG_SERVICES_OVERRIDE_JSON_PATH || '/config/services.override.json';
 
 export class Config {
-  constructor(configData) {
+  constructor(configData, configOverrideData) {
     this.exportConfigPath = configData.exportConfigPath;
     this.publisherUri = configData.publisherUri;
     //TODO: why here?
@@ -118,5 +119,12 @@ export class Config {
     this.key = configData.key || '';
     this.account = configData.account || 'http://services.lblod.info/diff-consumer/account';
     this.account_graph = configData.account_graph || 'http://mu.semte.ch/graphs/diff-producer/login';
+
+    // Apply configuration overrides, if any exist
+    if (configOverrideData != undefined) {
+      for (let key in configOverrideData) {
+        this[key] = configOverrideData[key];
+      }
     }
+  }
 }


### PR DESCRIPTION
## Ticket Number

DL-5580

## Ticket Description

When consolidating services into `delta-producer-publication-graph-maintainer` (most recently with `worship-submissions`), some configuration keys need to be specifically changed only on the QA and production servers.

Previously, this was easily done by adding entries in `docker-compose.override.yml`; however, the current method entails working around merge conflicts when pulling the changes on the server in addition to editing the main `config.json` file and making sure it looks intact.

In order to retain the override functionality, this PR adds support for a `config.override.json` file that contains any values a user wants overridden on their machine or on a remote server without having these changes tracked by git.

## How to Test

* Add the following to your `docker-compose.override.yml` inside `app-digitaal-loket`:
```
delta-producer-publication-graph-maintainer:
  environment:
    NODE_ENV: "development"
    CONFIG_SERVICES_OVERRIDE_JSON_PATH: '/config/publication-graph-maintainer/config.override.json'
  volumes:
    - ~/path/to/delta-producer-publication-graph-maintainer/:/app/
```

* Add a `config.override.json` file inside `config/delta-producer/publication-graph-maintainer/` in your local Loket repo folder with the following snippet:
```json
{
  "submissions": {
    "key": "B"
  }
}
```

* Check the output of `delta-producer-publication-graph-maintainer` for the configuration of each stream.

If you test on the latest commit of the Loket development branch, `"submissions"` should have `"key"` set to `"B"` whereas `"persons-sensitive"` and `"worship-submissions"` should still have `"key"` set to `''`.

## Note

I will be adding a PR on `app-digitaal-loket` to add the override config files to `.gitignore`. However, I want to first see how this PR goes first before proceeding further.