### PR TITLE
Fix/ensure graph filter on export type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delta-producer-publication-graph-maintainer",
-  "version": "1.1.1",
+  "version": "1.2.2",
   "description": "Microservice to maintain the publication graph during delta production process",
   "dependencies": {
     "@lazy-node/readlines": "^3.0.2",


### PR DESCRIPTION
When `strictTypeFilter` is set to true, previously it exported too much in some cases because the extra filters were not taken into account. This PR fixes this, meaning that even when exporting types, it still takes the extra filters into account.