### PR TITLE
Limit the amount of delta-files returned by `getDeltaFiles` to avoid timeout responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ The following enviroment variables can be optionally configured:
 * `PRETTY_PRINT_DIFF_JSON (default: true)`: Whether to pretty print the diff json
 * `CONFIG_SERVICES_JSON_PATH (default: '/config/services.json')`: The services configuration path
 * `MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE (defaut: 100)`: A delta is an object containing `inserts` and `deletes` properties. This variables specs the max. number of elements in these properties. This is mainly to tweak the size of the published delta files; where in some cases we need to tweak this number to reduce load on the consumers.
-* `MAX_DELTAS_PER_FILE: (default 10)`: Related to `MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE`, a delta-file bundles an array of delta-objects, here you configure the number of these delta-object per delta file. Again something to tweak only if you need to take care of the (potential) load on consumers.
+* `MAX_DELTAS_PER_FILE (default: 10)`: Related to `MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE`, a delta-file bundles an array of delta-objects, here you configure the number of these delta-object per delta file. Again something to tweak only if you need to take care of the (potential) load on consumers.
+* `MAX_DELTA_FILES_PER_REQUEST (default: 10_000)`: Limit the number of delta-files to be returned by `files?since=${timestamp}`. This is to prevent the service to crash when to many delta-files are present. 
 
 
 ### API

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The following enviroment variables can be optionally configured:
 * `CONFIG_SERVICES_JSON_PATH (default: '/config/services.json')`: The services configuration path
 * `MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE (defaut: 100)`: A delta is an object containing `inserts` and `deletes` properties. This variables specs the max. number of elements in these properties. This is mainly to tweak the size of the published delta files; where in some cases we need to tweak this number to reduce load on the consumers.
 * `MAX_DELTAS_PER_FILE (default: 10)`: Related to `MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE`, a delta-file bundles an array of delta-objects, here you configure the number of these delta-object per delta file. Again something to tweak only if you need to take care of the (potential) load on consumers.
-* `MAX_DELTA_FILES_PER_REQUEST (default: 10_000)`: Limit the number of delta-files to be returned by `files?since=${timestamp}`. This is to prevent the service to crash when to many delta-files are present. 
+* `MAX_DELTA_FILES_PER_REQUEST (default: 1000)`: Limit the number of delta-files to be returned by `files?since=${timestamp}`. This is to prevent the service to crash when to many delta-files are present. 
 
 
 ### API

--- a/env-config.js
+++ b/env-config.js
@@ -10,7 +10,7 @@ export const PUBLICATION_MU_AUTH_ENDPOINT = process.env.PUBLICATION_MU_AUTH_ENDP
 export const PRETTY_PRINT_DIFF_JSON = process.env.PRETTY_PRINT_DIFF_JSON === 'true';
 export const MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE = parseInt(process.env.MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE) || 100;
 export const MAX_DELTAS_PER_FILE = parseInt(process.env.MAX_DELTAS_PER_FILE) || 10;
-export const MAX_DELTA_FILES_PER_REQUEST = parseInt(process.env.MAX_DELTA_FILES_PER_REQUEST) || 10_000;
+export const MAX_DELTA_FILES_PER_REQUEST = parseInt(process.env.MAX_DELTA_FILES_PER_REQUEST) || 1000;
 export const CONFIG_SERVICES_JSON_PATH = process.env.CONFIG_SERVICES_JSON_PATH || '/config/services.json';
 
 export const DELTA_ERROR_TYPE = 'http://redpencil.data.gift/vocabularies/deltas/Error';

--- a/env-config.js
+++ b/env-config.js
@@ -10,6 +10,7 @@ export const PUBLICATION_MU_AUTH_ENDPOINT = process.env.PUBLICATION_MU_AUTH_ENDP
 export const PRETTY_PRINT_DIFF_JSON = process.env.PRETTY_PRINT_DIFF_JSON === 'true';
 export const MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE = parseInt(process.env.MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE) || 100;
 export const MAX_DELTAS_PER_FILE = parseInt(process.env.MAX_DELTAS_PER_FILE) || 10;
+export const MAX_DELTA_FILES_PER_REQUEST = parseInt(process.env.MAX_DELTA_FILES_PER_REQUEST) || 10_000;
 export const CONFIG_SERVICES_JSON_PATH = process.env.CONFIG_SERVICES_JSON_PATH || '/config/services.json';
 
 export const DELTA_ERROR_TYPE = 'http://redpencil.data.gift/vocabularies/deltas/Error';

--- a/files-publisher/delta-cache.js
+++ b/files-publisher/delta-cache.js
@@ -78,15 +78,16 @@ export default class DeltaCache {
     ${service_config.prefixes}
 
     SELECT ?uuid ?filename ?created WHERE {
-      ?s a nfo:FileDataObject ;
-          mu:uuid ?uuid ;
-          nfo:fileName ?filename ;
-          dct:publisher <${service_config.publisherUri}> ;
-          dct:created ?created .
-      ?file nie:dataSource ?s .
-
-      FILTER (?created > "${since}"^^xsd:dateTime)
-    } ORDER BY ?created LIMIT ${MAX_DELTA_FILES_PER_REQUEST}
+      SELECT distinct ?uuid ?filename ?created WHERE {
+        ?s a nfo:FileDataObject ;
+            mu:uuid ?uuid ;
+            nfo:fileName ?filename ;
+            dct:publisher <${service_config.publisherUri}> ;
+            dct:created ?created .
+        ?file nie:dataSource ?s .
+        FILTER (?created > "${since}"^^xsd:dateTime)
+      } ORDER BY ?created
+     } LIMIT ${MAX_DELTA_FILES_PER_REQUEST}
   `);
 
     return result.results.bindings.map(b => {

--- a/files-publisher/delta-cache.js
+++ b/files-publisher/delta-cache.js
@@ -3,7 +3,7 @@ import { updateSudo as update } from '@lblod/mu-auth-sudo';
 import fs from 'fs-extra';
 import { query, sparqlEscapeDateTime, uuid } from 'mu';
 import { storeError } from '../lib/utils';
-import {MAX_DELTAS_PER_FILE, MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE, PRETTY_PRINT_DIFF_JSON} from "../env-config";
+import {MAX_DELTAS_PER_FILE, MAX_TRIPLES_PER_OPERATION_IN_DELTA_FILE, MAX_DELTA_FILES_PER_REQUEST, PRETTY_PRINT_DIFF_JSON} from "../env-config";
 
 const SHARE_FOLDER = '/share';
 
@@ -65,14 +65,14 @@ export default class DeltaCache {
   }
 
   /**
-   * Get all delta files produced since a given timestamp
+   * Get all delta files produced since a given timestamp, up to a maximum of MAX_DELTA_FILES_PER_REQUEST
    *
    * @param service_config the configuration to be used
    * @param since {string} ISO date time
    * @public
   */
   async getDeltaFiles(service_config, since) {
-    console.log(`Retrieving delta files since ${since}`);
+    console.log(`Retrieving delta files since ${since}, up to ${MAX_DELTA_FILES_PER_REQUEST} files per query`);
 
     const result = await query(`
     ${service_config.prefixes}
@@ -86,7 +86,7 @@ export default class DeltaCache {
       ?file nie:dataSource ?s .
 
       FILTER (?created > "${since}"^^xsd:dateTime)
-    } ORDER BY ?created
+    } ORDER BY ?created LIMIT ${MAX_DELTA_FILES_PER_REQUEST}
   `);
 
     return result.results.bindings.map(b => {

--- a/files-publisher/delta-publisher.js
+++ b/files-publisher/delta-publisher.js
@@ -61,7 +61,7 @@ export default class DeltaPublisher {
   }
 
   /**
-   * Retrieves delta files generated since the specified timestamp.
+   * Retrieves delta files generated since the specified timestamp, up to a maximum of MAX_DELTA_FILES_PER_REQUEST.
    * @param {string} [since=new Date().toISOString()] - Timestamp to fetch delta files from.
    * @returns {Promise<Array>} Collection of delta files.
    */


### PR DESCRIPTION
The current synchronization between harvesters and Lokaal Beslist is broken due to the high volume of delta-files generated by the harvester. This overload causes 500 errors.

This PR introduces a limit to the `files?since=${timestamp}` endpoint. Editable via `MAX_DELTA_FILES_PER_REQUEST (default: 1000)` environment variable. 

With this change, consumers will need to make multiple requests to retrieve all data. Which aligns with the existing consumer behavior via the `delta-sync CronJob`. 