### PR TITLE
Hotfix: Support queryChunkSize in file-based healing [DL-6469]

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -159,7 +159,8 @@ export async function storeError(service_config, errorMsg) {
 export async function batchedQuery(subjectPredicateObjectQuery,
                                     batch = 100,
                                     sparqlEndpoint = MU_AUTH_ENDPOINT,
-                                    orderByStr = 'ORDER BY ?subject ?predicate ?object',
+                                   orderByStr = 'ORDER BY ?subject ?predicate ?object',
+                                   asConstructQuery = false
                                   ){
   if(!batch || batch == 0 || batch < 0) {
     const result = await query(subjectPredicateObjectQuery, {}, { sparqlEndpoint: sparqlEndpoint, mayRetry: true });
@@ -173,12 +174,23 @@ export async function batchedQuery(subjectPredicateObjectQuery,
     let offset = 0;
     let allTriples = [];
     while(offset <= numberOfResults){
-      const paginatedQuery = `
+      let paginatedQuery = `
         ${subjectPredicateObjectQuery}
         ${orderByStr}
         OFFSET ${offset}
         LIMIT ${batch}
       `;
+
+      if(asConstructQuery) {
+        paginatedQuery = `
+         CONSTRUCT{ ?subject ?predicate ?object }
+         WHERE {
+           {
+              ${paginatedQuery}
+           }
+         }
+         `
+      }
 
       const result = await query(paginatedQuery, {}, { sparqlEndpoint: sparqlEndpoint, mayRetry: true });
       const triples = result.results.bindings;


### PR DESCRIPTION


In some cases, the returned response is too big, causing Node to behave erratically, throwing errors like this:

```
/usr/src/output/node_modules/request/request.js:1140
      response.body = strings.join('')
 RangeError: Invalid string length
```

We've tackled this in the 'normal' healing, but it wasn't implemented in the 'file-based' healing.
This PR implements it. It's basically yet another performance workaround.