### PR TITLE
DL-7061: fix issue with `count` query being sent to wrong SPARQL endpoint

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,7 +111,7 @@ export async function batchedUpdate(nTriples, targetGraph,
   }
 }
 
-async function countResultSet(targetQuery){
+async function countResultSet(targetQuery, endpoint){
   const countQuery = `
      SELECT (COUNT(*) as ?total) {
         {
@@ -120,7 +120,7 @@ async function countResultSet(targetQuery){
      }
    `;
 
-  const result = await query(countQuery);
+  const result = await query(countQuery, {}, { sparqlEndpoint: endpoint, mayRetry: true });
 
   if(!(result.results || result.results.bindings.length)){
     return 0;
@@ -170,8 +170,12 @@ export async function batchedQuery(subjectPredicateObjectQuery,
     return triples;
   }
   else {
-    const numberOfResults = await countResultSet(subjectPredicateObjectQuery);
-    console.log(`Taking about ${numberOfResults} triples here`);
+    const numberOfResults = await countResultSet(subjectPredicateObjectQuery, sparqlEndpoint);
+    console.log(`Talking about ${numberOfResults} triples here`);
+    if(numberOfResults === 0){
+      // No reason to query virtuoso
+      return []
+    }
 
     let offset = 0;
     let allTriples = [];


### PR DESCRIPTION
### Overview
This PR fixes an issue with the logic in the `batchedQuery` function. The `sparqlEndpoint` argument of this function was not being passed correctly to the `countResultSet` function, which resulted in the function returning incomplete results.
As a result, the healing was not run correctly, and a lot of healing delta-files were being generated unnecessarily.

##### connected issues and PRs:
[DL-7061](https://binnenland.atlassian.net/browse/DL-7061?atlOrigin=eyJpIjoiN2ExNjViMTZjYWU4NGVmZjkxMGM5NDljNGI3MGI5ZTAiLCJwIjoiaiJ9)


### Setup
Include this service in your loket stack:
`docker-compose.override.yml`:
```yml
delta-producer-publication-graph-maintainer:
    image: !reset null
    build: https://github.com/lblod/delta-producer-publication-graph-maintainer.git#DL-7061-file-based-healing-issue
```
If working with production data: 
- increase the `MaxVectorSize` parameter in the `virtuoso.ini` files of both the `virtuoso` and `publication-triplestore` services (to at least 2000000).
- reduce the `delta-producer/worship-submissions/export.json` to a minimal config. The best resource type to test this PR with is `http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject`/`http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject`
- Expect the test to use a lot of ram (at least 32gb is recommended)

### How to test/reproduce
- Probably best to start from a production backup, or start from a QA backup and reduce the healing batch-size in such a way that it is less than the amount of triples it needs to query.
- Start at least the following services
  * virtuoso
  * publication-triplestore 
  * deltanotifier (with a reduced config, so it doesn't try to access unavailable endpoints)
  * database 
  * file 
  * jobs-controller 
  * delta-files-share 
  * delta-producer-background-jobs-initiator 
  * delta-producer-publication-graph-maintainer
- Attach a shell to `delta-producer-background-jobs-initiator` and run `curl -X POST http://localhost/worship-submissions/healing-jobs` to start a worship-submissions healing-job
- Wait a fair bit
- It is possible that the first healing job still produces delta-files, a second healing job should produce no delta files.

### Challenges/uncertainties
- Even when working with batched/paginated queries, we need to make sure that the  `MaxVectorSize` parameter is higher than the total result count. An alternative would be to work with scrollable cursors (https://docs.openlinksw.com/virtuoso/vscrlcursors/)
- Even the file-based approach still uses a lot of RAM (mostly by the two triplestore services)
- This bug has always been present in this service, but only recently caused incorrect heals, due to the amount of triples rising above 500000 (the configured batchsize).
